### PR TITLE
Adding webview delegate

### DIFF
--- a/JBWebViewController/JBWebViewController.h
+++ b/JBWebViewController/JBWebViewController.h
@@ -16,6 +16,12 @@
 #import <NJKWebViewProgress/NJKWebViewProgress.h>
 #import <NJKWebViewProgress/NJKWebViewProgressView.h>
 
+@class JBWebViewController;
+
+@protocol JBWebViewControllerDelegate <NSObject>
+- (BOOL)webController:(JBWebViewController *)controller shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType;
+@end
+
 @interface JBWebViewController : UIViewController <UIWebViewDelegate, NJKWebViewProgressDelegate>
 
 // Typedef for completion block
@@ -23,6 +29,7 @@ typedef void (^completion)(JBWebViewController *controller);
 
 // Loding string
 @property (nonatomic, strong) NSString *loadingString;
+@property (nonatomic, weak) id <JBWebViewControllerDelegate> delegate;
 
 // Public header methods
 - (id)initWithUrl:(NSURL *)url;

--- a/JBWebViewController/JBWebViewController.m
+++ b/JBWebViewController/JBWebViewController.m
@@ -338,7 +338,11 @@
 
 - (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType
 {
-    return true;
+    if (self.delegate) {
+        return [self.delegate webController:self shouldStartLoadWithRequest:request navigationType:navigationType];
+    } else {
+        return true;
+    }
 }
 
 - (void)webViewDidFinishLoad:(UIWebView *)webView


### PR DESCRIPTION
Reacting to redirects is useful in certain cases, especially when you might get a link to the app store or some other link that will open a different app. Adding a delegate helps apps using JBWebViewController react more intelligently.
